### PR TITLE
update to v1.54

### DIFF
--- a/bin/lsaBGC-Ready.py
+++ b/bin/lsaBGC-Ready.py
@@ -106,7 +106,7 @@ def create_parser():
     parser.add_argument('-f', '--fungal', action='store_true', help='Whether to run orthology inference in fungal mode - used if determining hierarchical orthologs via OrthoFinder.', required=False, default=False)
     parser.add_argument('-a', '--annotate', action='store_true', help='Perform annotation of BGC proteins using KOfam and PGAP (including TIGR)\nHMM profiles.', required=False, default=False)
     parser.add_argument('-t', '--run_gtotree', action='store_true', help='Whether to create phylogeny and expected sample-vs-sample\ndivergence for downstream analyses using GToTree.', required=False, default=False)
-    parser.add_argument('-gtm', '--gtotree_model', help='Set of core genes to use for phylogeny construction in GToTree\n[Default is Universal_Hug_et_al].', required=False, default="Universal_Hug_et_al")
+    parser.add_argument('-gtm', '--gtotree_model', help='Set of core genes to use for phylogeny construction in GToTree\n[Default is Universal-Hug-et-al].', required=False, default="Universal-Hug-et-al")
     parser.add_argument('-lc', '--lsabgc_cluster', action='store_true', help='Run lsaBGC-Cluster with default parameters. Note, we recommend running lsaBGC-Cluster\nmanually and exploring parameters through its ability to generate a user-report for setting\nclustering parameters.', required=False, default=False)
     parser.add_argument('-lci', '--lsabgc_cluster_inflation', type=float, help='Value for MCL inflation parameter to use in lsaBGC-Cluster [Default is 4.0].', required=False, default=4.0)
     parser.add_argument('-lcj', '--lsabgc_cluster_jaccard', type=float, help='Minimal Jaccard Index cutoff to regard two BGCs as potentially homologous\nin lsaBGC-Cluster [Default is 20.0].', required=False, default=20.0)
@@ -193,7 +193,7 @@ def lsaBGC_Ready():
         assert(gtotree_model in set(['Actinobacteria', 'Alphaproteobacteria', 'Bacteria', 'Archaea',
                                      'Bacteria_and_Archaea', 'Bacteroidetes', 'Betaproteobacteria', 'Chlamydiae',
                                      'Cyanobacteria', 'Epsilonproteobacteria', 'Firmicutes', 'Gammaproteobacteria',
-                                     'Proteobacteria', 'Tenericutes', 'Universal_Hug_et_al']))
+                                     'Proteobacteria', 'Tenericutes', 'Universal-Hug-et-al']))
     except:
         raise RuntimeError('Model for GToTree specified is not a valid model!')
 

--- a/scripts/setup_annotation_dbs.py
+++ b/scripts/setup_annotation_dbs.py
@@ -123,7 +123,7 @@ def setup_annot_dbs():
 
         actino_hmm_file = download_path + 'Actinobacteria.hmm'
         bacteria_hmm_file = download_path + 'Bacteria.hmm'
-        universal_hmm_file = download_path + 'Universal_Hug_et_al.hmm'
+        universal_hmm_file = download_path + 'Universal-Hug-et-al.hmm'
 
         if download_scc_hmms and not (os.path.isfile(actino_hmm_file) and os.path.isfile(bacteria_hmm_file) and os.path.isfile(universal_hmm_file)):
             print('Setting up GToTree SCC HMMs!')
@@ -137,7 +137,7 @@ def setup_annot_dbs():
                 assert (os.path.isfile(bacteria_hmm_file))
 
             if not os.path.isfile(universal_hmm_file):
-                os.system('wget https://zenodo.org/record/7860735/files/Universal_Hug_et_al.hmm?download=1 -O ' + universal_hmm_file)
+                os.system('wget https://zenodo.org/record/7860735/files/Universal-Hug-et-al.hmm?download=1 -O ' + universal_hmm_file)
                 assert (os.path.isfile(universal_hmm_file))
 
     except:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 from setuptools import setup
 
 setup(name='lsaBGC',
-      version='1.53',
+      version='1.54',
       description='Suite for comparative genomic, population genetics and evolutionary analysis, as well as metagenomic mining of micro-evolutionary novelty in BGCs all in the context of a single lineage of interest.',
       url='http://github.com/Kalan-Lab/lsaBGC/',
       author='Rauf Salamzade',

--- a/workflows/lsaBGC-Easy.py
+++ b/workflows/lsaBGC-Easy.py
@@ -372,12 +372,12 @@ def lsaBGC_Easy():
 
 		actino_hmm_file = lsaBGC_main_directory + '/db/Actinobacteria.hmm'
 		bacteria_hmm_file = lsaBGC_main_directory + '/db/Bacteria.hmm'
-		universal_hmm_file = lsaBGC_main_directory + '/db/Universal_et_al_Hug.hmm'
+		universal_hmm_file = lsaBGC_main_directory + '/db/Universal-et-al-Hug.hmm'
 
 		gtotree_model_arg = gtotree_model
 		if gtotree_model == 'Actinobacteria' and os.path.isfile(actino_hmm_file): gtotree_model_arg =  actino_hmm_file
 		elif gtotree_model == 'Bacteria' and os.path.isfile(bacteria_hmm_file): gtotree_model_arg = bacteria_hmm_file
-		elif gtotree_model == 'Universal_et_al_Hug' and os.path.isfile(universal_hmm_file): gtotree_model_arg = universal_hmm_file
+		elif gtotree_model == 'Universal-et-al-Hug' and os.path.isfile(universal_hmm_file): gtotree_model_arg = universal_hmm_file
 
 		gtotree_cmd = ['GToTree', '-A', all_proteomes_listing_file, '-H', gtotree_model_arg, '-n', str(max([cpus, 4])),
 					   '-j', str(parallel_jobs_4cpu), '-M', str(max([cpus, 4])), '-o', gtotree_outdir]
@@ -864,14 +864,14 @@ def checkModelIsValid(gtotree_model, docker_mode=False):
 			assert (gtotree_model in set(['Actinobacteria', 'Alphaproteobacteria', 'Bacteria', 'Archaea',
 										  'Bacteria_and_Archaea', 'Bacteroidetes', 'Betaproteobacteria', 'Chlamydiae',
 										  'Cyanobacteria', 'Epsilonproteobacteria', 'Firmicutes', 'Gammaproteobacteria',
-										  'Proteobacteria', 'Tenericutes', 'Universal_Hug_et_al']))
+										  'Proteobacteria', 'Tenericutes', 'Universal-Hug-et-al']))
 		except:
 			raise RuntimeError('Model for GToTree specified is not a valid model!')
 	else:
 		try:
-			assert (gtotree_model in set(['Actinobacteria', 'Bacteria', 'Universal_Hug_et_al']))
+			assert (gtotree_model in set(['Actinobacteria', 'Bacteria', 'Universal-Hug-et-al']))
 		except:
-			raise RuntimeError('Only GToTree SCC models for Actinobacteria, Bacteria, and Universal_Hug_et_al are available in Docker mode!\n')
+			raise RuntimeError('Only GToTree SCC models for Actinobacteria, Bacteria, and Universal-Hug-et-al are available in Docker mode!\n')
 
 def checkLsaBGCInputsExist(annotation_listing_file, gcf_listing_dir, orthogroups_matrix_file):
 	try:

--- a/workflows/lsaBGC-Easy.py
+++ b/workflows/lsaBGC-Easy.py
@@ -50,6 +50,7 @@ import resource
 from time import sleep
 from lsaBGC import util
 from ete3 import Tree
+import shutil
 
 os.environ['OMP_NUM_THREADS'] = '4'
 lsaBGC_main_directory = '/'.join(os.path.realpath(__file__).split('/')[:-2]) + '/'
@@ -366,7 +367,7 @@ def lsaBGC_Easy():
 	sys.stdout.write(
 		'--------------------\nStep 3\n--------------------\nBeginning construction of species tree using GToTree.\n')
 	if not os.path.isfile(species_tree_file) or not os.path.isfile(expected_similarities_file):
-		os.system('rm -rf %s' % gtotree_outdir)
+		shutil.rmtree(gtotree_outdir)
 
 		actino_hmm_file = lsaBGC_main_directory + '/db/Actinobacteria.hmm'
 		bacteria_hmm_file = lsaBGC_main_directory + '/db/Bacteria.hmm'
@@ -614,6 +615,56 @@ def lsaBGC_Easy():
 	logObject.info("Primary BGC predictions appear successful and are listed for samples/genomes at:\n%s" % primary_bgcs_listing_file)
 	sys.stdout.write("Primary BGC predictions appear successful and are listed for samples/genomes at:\n%s\n" % primary_bgcs_listing_file)
 
+	# Step 4.5: Check files before continuing to the bulk of the analysis
+	samples_with_bgcs = set([])
+	bgc_lines = {}
+	with open(primary_bgcs_listing_file) as opblf:
+		for line in opblf:
+			line = line.strip()
+			ls = line.split('\t')
+			samples_with_bgcs.add(ls[0])
+			bgc_lines[ls[0]] = line
+			
+	samples_with_pop_info = set([])
+	pop_lines = {}
+	with open(populations_file) as opf:
+		for line in opf:
+			line = line.strip()
+			ls = line.split('\t')
+			samples_with_pop_info.add(ls[0])
+			pop_lines[ls[0]] = line
+			
+	samples_kept_following_derep = set([])
+	derep_lines = {}
+	with open(samples_to_keep_file) as ostkf:
+		for line in ostkf:
+			line = line.strip()
+			ls = line.split('\t')
+			samples_kept_following_derep.add(ls[0])
+			derep_lines[ls[0]] = line
+			
+	final_sample_set = samples_with_bgcs.intersection(samples_with_pop_info).intersection(samples_kept_following_derep)
+
+	msg = 'After assessing samples to keep following dereplication, which samples\nhave population information, and which have BGC predictions performed successfully,\nthere are %d samples being considered for downstream analysis.' % len(final_sample_set)
+	sys.stdout.write(msg + '\n')
+	logObject.info(msg)
+	
+	# recreate files with only final samples
+	bgc_handle = open(primary_bgcs_listing_file, 'w')
+	pop_handle = open(populations_file, 'w')
+	der_handle = open(samples_to_keep_file, 'w')
+	for s in samples_with_bgcs:
+		samp_bgc_res = primary_bgc_pred_directory + s + '/'
+		if s in final_sample_set:
+			bgc_handle.write(bgc_lines[s] + '\n')
+			pop_handle.write(pop_lines[s] + '\n')
+			der_handle.write(der_lines[s] + '\n')
+		elif os.path.isdir(samp_bgc_res):
+			shutil.rmtree(samp_bgc_res)
+	bgc_handle.close()
+	pop_handle.close()
+	der_handle.close()
+	
 	# Step 5: Run lsaBGC-Ready.py with lsaBGC-Cluster or BiG-SCAPE
 	logObject.info('\n--------------------\nStep 5\n--------------------\nBeginning clustering of BGCs using either lsaBGC-Cluster (default) or BiG-SCAPE (can be requested).')
 	sys.stdout.write('--------------------\nStep 5\n--------------------\nBeginning clustering of BGCs using either lsaBGC-Cluster (default) or BiG-SCAPE (can be requested).\n')
@@ -644,7 +695,7 @@ def lsaBGC_Easy():
 	orthogroups_matrix_file = lsabgc_ready_results_directory + 'Orthogroups.tsv'
 	if not os.path.isdir(lsabgc_ready_results_directory) or len(
 			[f for f in os.listdir(lsabgc_ready_results_directory)]) <= 2:
-		os.system('rm -rf %s' % lsabgc_ready_directory)
+		shutil.rmtree(lsabgc_ready_directory)
 		lsabgc_ready_cmd = ['lsaBGC-Ready.py', '-i', primary_genomes_listing_file, '-l', primary_bgcs_listing_file,
 							'-o', lsabgc_ready_directory, '-c', str(cpus), '-p', bgc_prediction_software,
 							'-om', ortholog_method]
@@ -705,7 +756,7 @@ def lsaBGC_Easy():
 	lsabgc_autoanalyze_dir = outdir + 'lsaBGC_AutoAnalyze_Results/'
 	lsabgc_autoanalyze_results_dir = lsabgc_autoanalyze_dir + 'Final_Results/'
 	if not os.path.isdir(lsabgc_autoanalyze_results_dir):
-		os.system('rm -rf %s' % lsabgc_autoanalyze_dir)
+		shutil.rmtree(lsabgc_autoanalyze_dir)
 		lsabgc_autoanalyze_cmd = ['lsaBGC-AutoAnalyze.py', '-i', exp_annotation_listing_file, '-g', exp_gcf_listing_dir,
 								  '-mb', '-m', exp_orthogroups_matrix_file, '-s', species_tree_file, '-w',
 								  expected_similarities_file, '-k', samples_to_keep_file, '-c', str(cpus), '-o',
@@ -721,7 +772,7 @@ def lsaBGC_Easy():
 	gseef_results_dir = outdir + 'GSeeF_Results/'
 	gseef_final_results_dir = gseef_results_dir + 'Final_Results/'
 	if not os.path.isdir(gseef_results_dir):
-		os.system('rm -rf %s' % gseef_results_dir)
+		shutil.rmtree(gseef_results_dir)
 
 		pruned_species_tree_file = outdir + 'Species_Tree.pruned.tre'
 		try:

--- a/workflows/lsaBGC-Easy.py
+++ b/workflows/lsaBGC-Easy.py
@@ -94,7 +94,7 @@ def create_parser():
 	GToTree taxa models available (more resolute taxonomic groups will have more genes to use for building phylogeny):
 	(1) Actinobacteria, (2) Alphaproteobacteria, (3) Archaea, (4) Bacteria, (5) Bacteria_and_Archaea, 
  	(6) Betaproteobacteria, (7) Chlamydiae, (8) Cyanobacteria, (9) Epsilonproteobacteria, (10) Firmicutes, 
- 	(11) Firmicutes, (12) Gammaproteobacteria, (13) Proteobacteria, (14) Tenericutes, (15) Universal_Hug_et_al
+ 	(11) Firmicutes, (12) Gammaproteobacteria, (13) Proteobacteria, (14) Tenericutes, (15) Universal-Hug-et-al
  	*******************************************************************************************************************
 	""", formatter_class=argparse.RawTextHelpFormatter)
 

--- a/workflows/lsaBGC-Easy.py
+++ b/workflows/lsaBGC-Easy.py
@@ -618,13 +618,13 @@ def lsaBGC_Easy():
 
 	# Step 4.5: Check files before continuing to the bulk of the analysis
 	samples_with_bgcs = set([])
-	bgc_lines = {}
+	bgc_lines = defaultdict(list)
 	with open(primary_bgcs_listing_file) as opblf:
 		for line in opblf:
 			line = line.strip()
 			ls = line.split('\t')
 			samples_with_bgcs.add(ls[0])
-			bgc_lines[ls[0]] = line
+			bgc_lines[ls[0]].append(line)
 			
 	samples_with_pop_info = set([])
 	pop_lines = {}
@@ -660,7 +660,8 @@ def lsaBGC_Easy():
 	for s in samples_with_bgcs:
 		samp_bgc_res = primary_bgc_pred_directory + s + '/'
 		if s in final_sample_set:
-			bgc_handle.write(bgc_lines[s] + '\n')
+			for bl in bgc_lines[s]:
+				bgc_handle.write(bl + '\n')
 			pop_handle.write(pop_lines[s] + '\n')
 			der_handle.write(derep_lines[s] + '\n')
 		elif os.path.isdir(samp_bgc_res):

--- a/workflows/lsaBGC-Easy.py
+++ b/workflows/lsaBGC-Easy.py
@@ -659,7 +659,7 @@ def lsaBGC_Easy():
 		if s in final_sample_set:
 			bgc_handle.write(bgc_lines[s] + '\n')
 			pop_handle.write(pop_lines[s] + '\n')
-			der_handle.write(der_lines[s] + '\n')
+			der_handle.write(derep_lines[s] + '\n')
 		elif os.path.isdir(samp_bgc_res):
 			shutil.rmtree(samp_bgc_res)
 	bgc_handle.close()

--- a/workflows/lsaBGC-Easy.py
+++ b/workflows/lsaBGC-Easy.py
@@ -628,7 +628,7 @@ def lsaBGC_Easy():
 			
 	samples_with_pop_info = set([])
 	pop_lines = {}
-	with open(populations_file) as opf:
+	with open(population_file) as opf:
 		for line in opf:
 			line = line.strip()
 			ls = line.split('\t')
@@ -652,7 +652,7 @@ def lsaBGC_Easy():
 	
 	# recreate files with only final samples
 	bgc_handle = open(primary_bgcs_listing_file, 'w')
-	pop_handle = open(populations_file, 'w')
+	pop_handle = open(population_file, 'w')
 	der_handle = open(samples_to_keep_file, 'w')
 	for s in samples_with_bgcs:
 		samp_bgc_res = primary_bgc_pred_directory + s + '/'

--- a/workflows/lsaBGC-Easy.py
+++ b/workflows/lsaBGC-Easy.py
@@ -649,6 +649,9 @@ def lsaBGC_Easy():
 	msg = 'After assessing samples to keep following dereplication, which samples\nhave population information, and which have BGC predictions performed successfully,\nthere are %d samples being considered for downstream analysis.' % len(final_sample_set)
 	sys.stdout.write(msg + '\n')
 	logObject.info(msg)
+
+	if len(final_sample_set) == 0: 
+		sys.exit(1)
 	
 	# recreate files with only final samples
 	bgc_handle = open(primary_bgcs_listing_file, 'w')

--- a/workflows/lsaBGC-Easy.py
+++ b/workflows/lsaBGC-Easy.py
@@ -367,7 +367,8 @@ def lsaBGC_Easy():
 	sys.stdout.write(
 		'--------------------\nStep 3\n--------------------\nBeginning construction of species tree using GToTree.\n')
 	if not os.path.isfile(species_tree_file) or not os.path.isfile(expected_similarities_file):
-		shutil.rmtree(gtotree_outdir)
+		if os.path.isdir(gtotree_outdir):
+			shutil.rmtree(gtotree_outdir)
 
 		actino_hmm_file = lsaBGC_main_directory + '/db/Actinobacteria.hmm'
 		bacteria_hmm_file = lsaBGC_main_directory + '/db/Bacteria.hmm'
@@ -695,7 +696,8 @@ def lsaBGC_Easy():
 	orthogroups_matrix_file = lsabgc_ready_results_directory + 'Orthogroups.tsv'
 	if not os.path.isdir(lsabgc_ready_results_directory) or len(
 			[f for f in os.listdir(lsabgc_ready_results_directory)]) <= 2:
-		shutil.rmtree(lsabgc_ready_directory)
+		if os.path.isdir(lsabgc_ready_directory):
+			shutil.rmtree(lsabgc_ready_directory)
 		lsabgc_ready_cmd = ['lsaBGC-Ready.py', '-i', primary_genomes_listing_file, '-l', primary_bgcs_listing_file,
 							'-o', lsabgc_ready_directory, '-c', str(cpus), '-p', bgc_prediction_software,
 							'-om', ortholog_method]
@@ -756,7 +758,8 @@ def lsaBGC_Easy():
 	lsabgc_autoanalyze_dir = outdir + 'lsaBGC_AutoAnalyze_Results/'
 	lsabgc_autoanalyze_results_dir = lsabgc_autoanalyze_dir + 'Final_Results/'
 	if not os.path.isdir(lsabgc_autoanalyze_results_dir):
-		shutil.rmtree(lsabgc_autoanalyze_dir)
+		if os.path.isdir(lsabgc_autoanalyze_dir):
+			shutil.rmtree(lsabgc_autoanalyze_dir)
 		lsabgc_autoanalyze_cmd = ['lsaBGC-AutoAnalyze.py', '-i', exp_annotation_listing_file, '-g', exp_gcf_listing_dir,
 								  '-mb', '-m', exp_orthogroups_matrix_file, '-s', species_tree_file, '-w',
 								  expected_similarities_file, '-k', samples_to_keep_file, '-c', str(cpus), '-o',
@@ -772,7 +775,8 @@ def lsaBGC_Easy():
 	gseef_results_dir = outdir + 'GSeeF_Results/'
 	gseef_final_results_dir = gseef_results_dir + 'Final_Results/'
 	if not os.path.isdir(gseef_results_dir):
-		shutil.rmtree(gseef_results_dir)
+		if os.path.isdir(gseef_results_dir):
+			shutil.rmtree(gseef_results_dir)
 
 		pruned_species_tree_file = outdir + 'Species_Tree.pruned.tre'
 		try:

--- a/workflows/lsaBGC-Euk-Easy.py
+++ b/workflows/lsaBGC-Euk-Easy.py
@@ -288,7 +288,7 @@ def lsaBGC_Euk_Easy():
 		os.system('rm -rf %s' % gtotree_outdir)
 		universal_hmm_file = lsaBGC_main_directory + '/db/Universal_Hug_et_al.hmm'
 
-		gtotree_model_arg = "Universal_Hug_et_al"
+		gtotree_model_arg = "Universal-Hug-et-al"
 		if os.path.isfile(universal_hmm_file): gtotree_model_arg = universal_hmm_file
 
 		gtotree_cmd = ['GToTree', '-A', all_proteomes_listing_file, '-H', gtotree_model_arg, '-n', str(max([cpus, 4])),

--- a/workflows/lsaBGC-Euk-Easy.py
+++ b/workflows/lsaBGC-Euk-Easy.py
@@ -524,7 +524,7 @@ def lsaBGC_Euk_Easy():
 			
 	samples_with_pop_info = set([])
 	pop_lines = {}
-	with open(populations_file) as opf:
+	with open(population_file) as opf:
 		for line in opf:
 			line = line.strip()
 			ls = line.split('\t')
@@ -548,7 +548,7 @@ def lsaBGC_Euk_Easy():
 	
 	# recreate files with only final samples
 	bgc_handle = open(primary_bgcs_listing_file, 'w')
-	pop_handle = open(populations_file, 'w')
+	pop_handle = open(population_file, 'w')
 	der_handle = open(samples_to_keep_file, 'w')
 	for s in samples_with_bgcs:
 		samp_bgc_res = primary_bgc_pred_directory + s + '/'

--- a/workflows/lsaBGC-Euk-Easy.py
+++ b/workflows/lsaBGC-Euk-Easy.py
@@ -540,6 +540,10 @@ def lsaBGC_Euk_Easy():
 			derep_lines[ls[0]] = line
 			
 	final_sample_set = samples_with_bgcs.intersection(samples_with_pop_info).intersection(samples_kept_following_derep)
+
+	msg = 'After assessing samples to keep following dereplication, which samples\nhave population information, and which have BGC predictions performed successfully,\nthere are %d samples being considered for downstream analysis.' % len(final_sample_set)
+	sys.stdout.write(msg + '\n')
+	logObject.info(msg)
 	
 	# recreate files with only final samples
 	bgc_handle = open(primary_bgcs_listing_file, 'w')

--- a/workflows/lsaBGC-Euk-Easy.py
+++ b/workflows/lsaBGC-Euk-Easy.py
@@ -286,7 +286,8 @@ def lsaBGC_Euk_Easy():
 	logObject.info('\n--------------------\nStep 3\n--------------------\nBeginning construction of species tree using GToTree.')
 	sys.stdout.write('--------------------\nStep 3\n--------------------\nBeginning construction of species tree using GToTree.\n')
 	if not os.path.isfile(species_tree_file) or not os.path.isfile(expected_similarities_file):
-		shutil.rmtree(gtotree_outdir)
+		if os.path.isdir(gtotree_outdir):
+			shutil.rmtree(gtotree_outdir)
 		universal_hmm_file = lsaBGC_main_directory + '/db/Universal_Hug_et_al.hmm'
 
 		gtotree_model_arg = "Universal-Hug-et-al"
@@ -587,7 +588,8 @@ def lsaBGC_Euk_Easy():
 	orthogroups_matrix_file = lsabgc_ready_results_directory + 'Orthogroups.tsv'
 	if not os.path.isdir(lsabgc_ready_results_directory) or len(
 			[f for f in os.listdir(lsabgc_ready_results_directory)]) <= 2:
-		shutil.rmtree(lsabgc_ready_directory)
+		if os.path.isdir(lsabgc_ready_directory):
+			shutil.rmtree(lsabgc_ready_directory)
 		lsabgc_ready_cmd = ['lsaBGC-Ready.py', '-i', primary_genomes_listing_file, '-l', primary_bgcs_listing_file,
 							'-o', lsabgc_ready_directory, '-c', str(cpus), '-p', 'antiSMASH', '-om', ortholog_method, 
 							'-f']
@@ -645,7 +647,8 @@ def lsaBGC_Euk_Easy():
 	lsabgc_autoanalyze_dir = outdir + 'lsaBGC_AutoAnalyze_Results/'
 	lsabgc_autoanalyze_results_dir = lsabgc_autoanalyze_dir + 'Final_Results/'
 	if not os.path.isdir(lsabgc_autoanalyze_results_dir):
-		shutil.rmtree(lsabgc_autoanalyze_dir)
+		if os.path.isdir(lsabgc_autoanalyze_dir):
+			shutil.rmtree(lsabgc_autoanalyze_dir)
 		lsabgc_autoanalyze_cmd = ['lsaBGC-AutoAnalyze.py', '-i', exp_annotation_listing_file, '-g', exp_gcf_listing_dir,
 								  '-m', exp_orthogroups_matrix_file, '-mb', '-s', species_tree_file, '-w',
 								  expected_similarities_file, '-k', samples_to_keep_file, '-c', str(cpus), '-o',
@@ -661,7 +664,8 @@ def lsaBGC_Euk_Easy():
 	gseef_results_dir = outdir + 'GSeeF_Results/'
 	gseef_final_results_dir = gseef_results_dir + 'Final_Results/'
 	if not os.path.isdir(gseef_results_dir):
-		shutil.rmtree(gseef_results_dir)
+		if os.path.isdir(gseef_results_dir):
+			shutil.rmtree(gseef_results_dir)
 
 		pruned_species_tree_file = outdir + 'Species_Tree.pruned.tre'
 		try:

--- a/workflows/lsaBGC-Euk-Easy.py
+++ b/workflows/lsaBGC-Euk-Easy.py
@@ -545,7 +545,10 @@ def lsaBGC_Euk_Easy():
 	msg = 'After assessing samples to keep following dereplication, which samples\nhave population information, and which have BGC predictions performed successfully,\nthere are %d samples being considered for downstream analysis.' % len(final_sample_set)
 	sys.stdout.write(msg + '\n')
 	logObject.info(msg)
-	
+
+	if len(final_sample_set) == 0: 
+		sys.exit(1)
+
 	# recreate files with only final samples
 	bgc_handle = open(primary_bgcs_listing_file, 'w')
 	pop_handle = open(population_file, 'w')

--- a/workflows/lsaBGC-Euk-Easy.py
+++ b/workflows/lsaBGC-Euk-Easy.py
@@ -555,7 +555,7 @@ def lsaBGC_Euk_Easy():
 		if s in final_sample_set:
 			bgc_handle.write(bgc_lines[s] + '\n')
 			pop_handle.write(pop_lines[s] + '\n')
-			der_handle.write(der_lines[s] + '\n')
+			der_handle.write(derep_lines[s] + '\n')
 		elif os.path.isdir(samp_bgc_res):
 			shutil.rmtree(samp_bgc_res)
 	bgc_handle.close()

--- a/workflows/lsaBGC-Euk-Easy.py
+++ b/workflows/lsaBGC-Euk-Easy.py
@@ -514,13 +514,13 @@ def lsaBGC_Euk_Easy():
 
 	# Step 4.5: Check files before continuing to the bulk of the analysis
 	samples_with_bgcs = set([])
-	bgc_lines = {}
+	bgc_lines = defaultdict(list)
 	with open(primary_bgcs_listing_file) as opblf:
 		for line in opblf:
 			line = line.strip()
 			ls = line.split('\t')
 			samples_with_bgcs.add(ls[0])
-			bgc_lines[ls[0]] = line
+			bgc_lines[ls[0]].append(line)
 			
 	samples_with_pop_info = set([])
 	pop_lines = {}
@@ -556,7 +556,8 @@ def lsaBGC_Euk_Easy():
 	for s in samples_with_bgcs:
 		samp_bgc_res = primary_bgc_pred_directory + s + '/'
 		if s in final_sample_set:
-			bgc_handle.write(bgc_lines[s] + '\n')
+			for bl in bgc_lines[s]:
+				bgc_handle.write(bl + '\n')
 			pop_handle.write(pop_lines[s] + '\n')
 			der_handle.write(derep_lines[s] + '\n')
 		elif os.path.isdir(samp_bgc_res):

--- a/workflows/lsaBGC-Euk-Easy.py
+++ b/workflows/lsaBGC-Euk-Easy.py
@@ -50,6 +50,7 @@ import resource
 from time import sleep
 from lsaBGC import util
 from ete3 import Tree
+import shutil
 
 os.environ['OMP_NUM_THREADS'] = '4'
 lsaBGC_main_directory = '/'.join(os.path.realpath(__file__).split('/')[:-2]) + '/'
@@ -285,7 +286,7 @@ def lsaBGC_Euk_Easy():
 	logObject.info('\n--------------------\nStep 3\n--------------------\nBeginning construction of species tree using GToTree.')
 	sys.stdout.write('--------------------\nStep 3\n--------------------\nBeginning construction of species tree using GToTree.\n')
 	if not os.path.isfile(species_tree_file) or not os.path.isfile(expected_similarities_file):
-		os.system('rm -rf %s' % gtotree_outdir)
+		shutil.rmtree(gtotree_outdir)
 		universal_hmm_file = lsaBGC_main_directory + '/db/Universal_Hug_et_al.hmm'
 
 		gtotree_model_arg = "Universal-Hug-et-al"
@@ -510,6 +511,52 @@ def lsaBGC_Euk_Easy():
 	logObject.info("Primary BGC predictions appear successful and are listed for samples/genomes at:\n%s" % primary_bgcs_listing_file)
 	sys.stdout.write("Primary BGC predictions appear successful and are listed for samples/genomes at:\n%s\n" % primary_bgcs_listing_file)
 
+	# Step 4.5: Check files before continuing to the bulk of the analysis
+	samples_with_bgcs = set([])
+	bgc_lines = {}
+	with open(primary_bgcs_listing_file) as opblf:
+		for line in opblf:
+			line = line.strip()
+			ls = line.split('\t')
+			samples_with_bgcs.add(ls[0])
+			bgc_lines[ls[0]] = line
+			
+	samples_with_pop_info = set([])
+	pop_lines = {}
+	with open(populations_file) as opf:
+		for line in opf:
+			line = line.strip()
+			ls = line.split('\t')
+			samples_with_pop_info.add(ls[0])
+			pop_lines[ls[0]] = line
+			
+	samples_kept_following_derep = set([])
+	derep_lines = {}
+	with open(samples_to_keep_file) as ostkf:
+		for line in ostkf:
+			line = line.strip()
+			ls = line.split('\t')
+			samples_kept_following_derep.add(ls[0])
+			derep_lines[ls[0]] = line
+			
+	final_sample_set = samples_with_bgcs.intersection(samples_with_pop_info).intersection(samples_kept_following_derep)
+	
+	# recreate files with only final samples
+	bgc_handle = open(primary_bgcs_listing_file, 'w')
+	pop_handle = open(populations_file, 'w')
+	der_handle = open(samples_to_keep_file, 'w')
+	for s in samples_with_bgcs:
+		samp_bgc_res = primary_bgc_pred_directory + s + '/'
+		if s in final_sample_set:
+			bgc_handle.write(bgc_lines[s] + '\n')
+			pop_handle.write(pop_lines[s] + '\n')
+			der_handle.write(der_lines[s] + '\n')
+		elif os.path.isdir(samp_bgc_res):
+			shutil.rmtree(samp_bgc_res)
+	bgc_handle.close()
+	pop_handle.close()
+	der_handle.close()
+	
 	# Step 5: Run lsaBGC-Ready.py with lsaBGC-Cluster or BiG-SCAPE
 	logObject.info('\n--------------------\nStep 5\n--------------------\nBeginning clustering of BGCs using either lsaBGC-Cluster (default) or BiG-SCAPE (can be requested).')
 	sys.stdout.write('--------------------\nStep 5\n--------------------\nBeginning clustering of BGCs using either lsaBGC-Cluster (default) or BiG-SCAPE (can be requested).\n')
@@ -536,7 +583,7 @@ def lsaBGC_Euk_Easy():
 	orthogroups_matrix_file = lsabgc_ready_results_directory + 'Orthogroups.tsv'
 	if not os.path.isdir(lsabgc_ready_results_directory) or len(
 			[f for f in os.listdir(lsabgc_ready_results_directory)]) <= 2:
-		os.system('rm -rf %s' % lsabgc_ready_directory)
+		shutil.rmtree(lsabgc_ready_directory)
 		lsabgc_ready_cmd = ['lsaBGC-Ready.py', '-i', primary_genomes_listing_file, '-l', primary_bgcs_listing_file,
 							'-o', lsabgc_ready_directory, '-c', str(cpus), '-p', 'antiSMASH', '-om', ortholog_method, 
 							'-f']
@@ -594,7 +641,7 @@ def lsaBGC_Euk_Easy():
 	lsabgc_autoanalyze_dir = outdir + 'lsaBGC_AutoAnalyze_Results/'
 	lsabgc_autoanalyze_results_dir = lsabgc_autoanalyze_dir + 'Final_Results/'
 	if not os.path.isdir(lsabgc_autoanalyze_results_dir):
-		os.system('rm -rf %s' % lsabgc_autoanalyze_dir)
+		shutil.rmtree(lsabgc_autoanalyze_dir)
 		lsabgc_autoanalyze_cmd = ['lsaBGC-AutoAnalyze.py', '-i', exp_annotation_listing_file, '-g', exp_gcf_listing_dir,
 								  '-m', exp_orthogroups_matrix_file, '-mb', '-s', species_tree_file, '-w',
 								  expected_similarities_file, '-k', samples_to_keep_file, '-c', str(cpus), '-o',
@@ -610,7 +657,7 @@ def lsaBGC_Euk_Easy():
 	gseef_results_dir = outdir + 'GSeeF_Results/'
 	gseef_final_results_dir = gseef_results_dir + 'Final_Results/'
 	if not os.path.isdir(gseef_results_dir):
-		os.system('rm -rf %s' % gseef_results_dir)
+		shutil.rmtree(gseef_results_dir)
 
 		pruned_species_tree_file = outdir + 'Species_Tree.pruned.tre'
 		try:


### PR DESCRIPTION
- update GToTree references to HMM models for Universal ribosomal proteins to use dashes instead of underscores.
- update handling of cases where genomes fail to be processed during BGC prediction or are dropped by GToTree when constructing a phylogeny in the lsaBGC-(Euk)-Easy workflows.